### PR TITLE
Support disabling by Html5Validators.config

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -75,7 +75,7 @@ http://img.skitch.com/20110516-n3jhu5m4gan8iy1j8er1qb7yfa.jpg
 
 == Disabling automatic client-side validation
 
-There are three ways to cancel the automatic HTML5 validation
+There are four ways to cancel the automatic HTML5 validation
 
 * form_for option
 
@@ -114,6 +114,17 @@ Write `auto_html5_validation = false` in ActiveModelish class
     <%= form_for @user do |f| %>
       ...
     <% end %>
+
+* html5_validators configuration
+
+Set `config.enabled = false` in Html5Validators
+
+  Controller:
+    around_action do |controller, block|
+      Html5Validators.config.enabled = false if params[:h5v] == 'disable'
+      block.call
+      Html5Validators.config.enabled = true if params[:h5v] == 'disable'
+    end
 
 
 == Supported versions

--- a/lib/html5_validators.rb
+++ b/lib/html5_validators.rb
@@ -1,6 +1,16 @@
 require 'rails'
 
 module Html5Validators
+  @@enabled = true
+
+  def self.enabled
+    @@enabled
+  end
+
+  def self.enabled= enable
+    @@enabled = enable
+  end
+
   class Railtie < ::Rails::Railtie #:nodoc:
     initializer 'html5_validators' do |app|
       ActiveSupport.on_load(:active_record) do

--- a/lib/html5_validators/action_view/form_helpers.rb
+++ b/lib/html5_validators/action_view/form_helpers.rb
@@ -19,7 +19,11 @@ module ActionView
   module Helpers
     module FormHelper
       def form_for_with_auto_html5_validation_option(record, options = {}, &proc)
-        record.auto_html5_validation = false if (options[:auto_html5_validation] == false) && (record.respond_to? :auto_html5_validation=)
+        if record.respond_to?(:auto_html5_validation=)
+          if !Html5Validators.enabled || (options[:auto_html5_validation] == false)
+            record.auto_html5_validation = false
+          end
+        end
         form_for_without_auto_html5_validation_option record, options, &proc
       end
       alias_method_chain :form_for, :auto_html5_validation_option

--- a/spec/features/validation_spec.rb
+++ b/spec/features/validation_spec.rb
@@ -51,6 +51,21 @@ feature 'person#new' do
         find('input#person_name')[:required].should be_nil
       end
     end
+
+    context 'disabling html5_validations in gem' do
+      background do
+        Html5Validators.enabled = false
+      end
+      after do
+        Html5Validators.enabled = true
+      end
+      scenario 'new form' do
+        visit '/people/new'
+
+        find('input#person_name')[:required].should be_nil
+        find('textarea#person_bio')[:required].should be_nil
+      end
+    end
   end
 
   context 'with maxlength validation' do


### PR DESCRIPTION
Add support disabling in `Html5Validators.config.enabled`.
This is useful when we test form behavior in legacy browsers.