### PR TITLE
Call 'stringify_keys' on the @options object before using it.

### DIFF
--- a/lib/html5_validators/action_view/form_helpers.rb
+++ b/lib/html5_validators/action_view/form_helpers.rb
@@ -2,13 +2,15 @@ module Html5Validators
   module ActionViewExtension
     def inject_required_field
       if object.class.ancestors.include?(ActiveModel::Validations) && (object.auto_html5_validation != false) && (object.class.auto_html5_validation != false)
-        @options["required"] ||= object.class.attribute_required?(@method_name)
+        options = @options.stringify_keys
+        @options["required"] = options["required"] || object.class.attribute_required?(@method_name)
       end
     end
 
     def inject_maxlength_field
       if object.class.ancestors.include?(ActiveModel::Validations) && (object.auto_html5_validation != false) && (object.class.auto_html5_validation != false)
-        @options["maxlength"] ||= object.class.attribute_maxlength(@method_name)
+        options = @options.stringify_keys
+        @options["maxlength"] = options["maxlength"] || object.class.attribute_maxlength(@method_name)
       end
     end
   end
@@ -37,8 +39,9 @@ module ActionView
             inject_maxlength_field
 
             if object.class.ancestors.include?(ActiveModel::Validations) && (object.auto_html5_validation != false) && (object.class.auto_html5_validation != false)
-              @options["max"] ||= object.class.attribute_max(@method_name)
-              @options["min"] ||= object.class.attribute_min(@method_name)
+              options = @options.stringify_keys
+              @options["max"] = options["maxlength"] || object.class.attribute_max(@method_name)
+              @options["min"] = options["maxlength"] || object.class.attribute_min(@method_name)
             end
             render_without_html5_attributes
           end

--- a/spec/fake_app.rb
+++ b/spec/fake_app.rb
@@ -16,6 +16,7 @@ app.routes.draw do
   resources :people, :only => [:new, :create] do
     collection do
       get :new_without_html5_validation
+      get :new_with_required_true
     end
   end
 end
@@ -45,6 +46,15 @@ ERB
 <%= f.text_field :email %>
 <% end %>
 ERB
+  end
+
+  def new_with_required_true
+    @person = Person.new
+    render :inline => <<-ERB
+<%= form_for @person do |f| %>
+<%= f.text_field :email, :required => true %>
+<% end %>
+    ERB
   end
 end
 

--- a/spec/features/validation_spec.rb
+++ b/spec/features/validation_spec.rb
@@ -33,6 +33,11 @@ feature 'person#new' do
 
       find('input#person_name')[:required].should be_nil
     end
+    scenario 'new_with_required_true form' do
+      visit '/people/new_with_required_true'
+
+      find('input#person_email')[:required].should == 'required'
+    end
 
     context 'disabling html5_validation in class level' do
       background do


### PR DESCRIPTION
I needed to manually set the required attribute on a field. It had a conditional validator that I knew would fire in this use-case. My view contained: 
```ruby
<%= f.text_field :family_name, required: true %>
```
But the `required` attribute was never generated.

The implementation in `html5_validators/action_view/form_helpers.rb` appeared to support this use-case with the `@options ||= ...` line, but when I debugged into it `@options["required"]` was always nil.

I reviewed one of the Rails classes (TextField) and noted they called `stringify_keys` on the `@options` object before using it. The same solution worked here. For my sample field above I now get a required attrubute in the HTML:
```html
<input required="required" type="text" name="user[family_name]" id="user_family_name">
```