### PR TITLE
Fix behavior of numericality validations for the *_than vs. *_than_or_equal_to validations

### DIFF
--- a/lib/html5_validators/active_model/helper_methods.rb
+++ b/lib/html5_validators/active_model/helper_methods.rb
@@ -20,15 +20,29 @@ module ActiveModel
       end
 
       def attribute_max(attribute)
-        self.validators.grep(NumericalityValidator).select {|v|
-          v.attributes.include?(attribute.to_sym) && (v.options.keys & [:less_than, :less_than_or_equal_to]).any? && (v.options.keys & [:if, :unless, :allow_nil, :allow_blank]).empty?
-        }.map {|v| v.options.slice(:less_than, :less_than_or_equal_to)}.map(&:values).flatten.max
+        less_than_max = self.validators.grep(NumericalityValidator).select {|v|
+          v.attributes.include?(attribute.to_sym) && (v.options.keys & [:less_than]).any? && (v.options.keys & [:if, :unless, :allow_nil, :allow_blank]).empty?
+        }.map {|v| v.options.slice(:less_than)}.map(&:values).flatten.max
+        less_than_max = less_than_max - 1 if less_than_max # Ensure we're not allowing the value to be equal to the max specified
+
+        less_than_or_equal_to_max = self.validators.grep(NumericalityValidator).select {|v|
+          v.attributes.include?(attribute.to_sym) && (v.options.keys & [:less_than_or_equal_to]).any? && (v.options.keys & [:if, :unless, :allow_nil, :allow_blank]).empty?
+        }.map {|v| v.options.slice(:less_than_or_equal_to)}.map(&:values).flatten.max
+
+        [less_than_max, less_than_or_equal_to_max].compact.max
       end
 
       def attribute_min(attribute)
-        self.validators.grep(NumericalityValidator).select {|v|
-          v.attributes.include?(attribute.to_sym) && (v.options.keys & [:greater_than, :greater_than_or_equal_to]).any? && (v.options.keys & [:if, :unless, :allow_nil, :allow_blank]).empty?
-        }.map {|v| v.options.slice(:greater_than, :greater_than_or_equal_to)}.map(&:values).flatten.min
+        greater_than_min = self.validators.grep(NumericalityValidator).select {|v|
+          v.attributes.include?(attribute.to_sym) && (v.options.keys & [:greater_than]).any? && (v.options.keys & [:if, :unless, :allow_nil, :allow_blank]).empty?
+        }.map {|v| v.options.slice(:greater_than)}.map(&:values).flatten.min
+        greater_than_min = greater_than_min + 1 if greater_than_min # Ensure we're not allowing the value to be equal to the min specified
+
+        greater_than_or_equal_to_min = self.validators.grep(NumericalityValidator).select {|v|
+          v.attributes.include?(attribute.to_sym) && (v.options.keys & [:greater_than_or_equal_to]).any? && (v.options.keys & [:if, :unless, :allow_nil, :allow_blank]).empty?
+        }.map {|v| v.options.slice(:greater_than_or_equal_to)}.map(&:values).flatten.min
+
+        [greater_than_min, greater_than_or_equal_to_min].compact.min
       end
     end
   end


### PR DESCRIPTION
- Changed the behavior of attribute_max and attribute_min so it treats :less_than/:greater_than
  differently from :less_than_or_equal_to/:greater_than_or_equal_to.  Specifically it just adds
  1 to :greater_than's value and subtracts 1 from :less_than's value.
