### PR TITLE
Fix "required" option evaluation

### DIFF
--- a/lib/html5_validators/action_view/form_helpers.rb
+++ b/lib/html5_validators/action_view/form_helpers.rb
@@ -14,7 +14,8 @@ module Html5Validators
     module PresenceValidator
       def render
         if object.class.ancestors.include?(ActiveModel::Validations) && (object.auto_html5_validation != false) && (object.class.auto_html5_validation != false)
-          @options["required"] ||= @options[:required] || object.class.attribute_required?(@method_name)
+          @options["required"] = @options[:required] if @options["required"].nil?
+          @options["required"] = object.class.attribute_required?(@method_name) if @options["required"].nil?
         end
         super
       end


### PR DESCRIPTION
   form.file_field :file, required: false
the above line was always rendered with required: :required
