### PR TITLE
allow maxlength validation for inputs which can be blank

### DIFF
--- a/lib/html5_validators/active_model/helper_methods.rb
+++ b/lib/html5_validators/active_model/helper_methods.rb
@@ -9,7 +9,7 @@ module ActiveModel
 
       def attribute_maxlength(attribute)
         self.validators.grep(LengthValidator).select {|v|
-          v.attributes.include?(attribute.to_sym) && (v.options.keys & [:maximum, :is]).any? && (v.options.keys & [:if, :unless, :allow_nil, :allow_blank, :tokenizer]).empty?
+          v.attributes.include?(attribute.to_sym) && (v.options.keys & [:maximum, :is]).any? && (v.options.keys & [:if, :unless, :tokenizer]).empty?
         }.map {|v| v.options.slice(:maximum, :is)}.map(&:values).flatten.max
       end
 


### PR DESCRIPTION
Before:
```ruby
validates :company_url, allow_blank: true, length: { maximum: 255 }
```
was translated to:
```html
<input type="url" name="company[company_url]" id="company_company_url" />
```
Now it's translated to:
```html
<input maxlength="255" size="255" type="url" name="company[company_url]" id="company_company_url" />
```