### PR TITLE
Fix `required: false` override on PresenceValidator

### DIFF
--- a/lib/html5_validators/action_view/form_helpers.rb
+++ b/lib/html5_validators/action_view/form_helpers.rb
@@ -15,7 +15,7 @@ module Html5Validators
     module PresenceValidator
       def render
         if object.class.ancestors.include?(ActiveModel::Validations) && (object.auto_html5_validation != false) && (object.class.auto_html5_validation != false)
-          @options["required"] ||= @options[:required] || object.class.attribute_required?(@method_name)
+          @options["required"] ||= @options.fetch(:required) { object.class.attribute_required?(@method_name) }
         end
         super
       end

--- a/test/fake_app.rb
+++ b/test/fake_app.rb
@@ -18,12 +18,14 @@ app.routes.draw do
     collection do
       get :new_without_html5_validation
       get :new_with_required_true
+      get :new_with_required_false
     end
   end
   resources :items, only: [:new, :create] do
     collection do
       get :new_without_html5_validation
       get :new_with_required_true
+      get :new_with_required_false
     end
   end
 end
@@ -77,6 +79,15 @@ ERB
 <% end %>
     ERB
   end
+
+  def new_with_required_false
+    @person = Person.new
+    render inline: <<-ERB
+<%= form_for @person do |f| %>
+<%= f.text_field :email, required: false %>
+<% end %>
+    ERB
+  end
 end
 class ItemsController < ApplicationController
   def new
@@ -104,6 +115,15 @@ ERB
     render inline: <<-ERB
 <%= form_for @item do |f| %>
 <%= f.text_field :name, required: true %>
+<% end %>
+    ERB
+  end
+
+  def new_with_required_false
+    @item = Item.new
+    render inline: <<-ERB
+<%= form_for @item do |f| %>
+<%= f.text_field :name, required: false %>
 <% end %>
     ERB
   end

--- a/test/features/validation_test.rb
+++ b/test/features/validation_test.rb
@@ -39,7 +39,11 @@ class ActiveRecordValidationTest < ActionDispatch::IntegrationTest
 
       assert_equal 'required', find('input#person_email')[:required]
     end
+    test 'new_with_required_false form' do
+      visit '/people/new_with_required_false'
 
+      assert_nil find('input#person_email')[:required]
+    end
     sub_test_case 'disabling html5_validation in class level' do
       setup do
         Person.class_eval do |kls|
@@ -141,7 +145,11 @@ class ActiveModelValidationTest < ActionDispatch::IntegrationTest
 
       assert_equal 'required', find('input#item_name')[:required]
     end
+    test 'new_with_required_false form' do
+      visit '/items/new_with_required_false'
 
+      assert_nil find('input#item_name')[:required]
+    end
     sub_test_case 'disabling html5_validation in class level' do
       setup do
         Item.class_eval do |kls|


### PR DESCRIPTION
Explanation: We often come across situations where in we don't want to force certain validations on client side and they can be fulfilled at server side. Currently we are not able to override required option for input field.

Spec: Allow `required: false` override on `PresenceValidator`

Note: Test coverage is added.