### PR TITLE
Fix CI failures.

### DIFF
--- a/html5_validators.gemspec
+++ b/html5_validators.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
   s.add_development_dependency 'test-unit-rails'
+  s.add_development_dependency 'selenium-webdriver'
+  s.add_development_dependency 'puma'
   s.add_development_dependency 'capybara', '>= 2'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rake'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,12 +7,7 @@ require 'rails'
 require 'bundler/setup'
 Bundler.require
 require 'capybara'
-require "selenium/webdriver"
-
-Capybara.register_driver :selenium do |app|
-  Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: Selenium::WebDriver::Remote::Capabilities.chrome(chrome_options: {args: ['headless', 'disable-gpu', 'no-sandbox']}))
-end
-Capybara.default_driver = :selenium
+require 'selenium/webdriver'
 
 # needs to load the app before loading rspec/rails => capybara
 require 'fake_app'
@@ -20,6 +15,18 @@ require 'test/unit/rails/test_help'
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
+
+begin
+  require "action_dispatch/system_test_case"
+rescue LoadError
+  Capybara.register_driver :chrome do |app|
+    options = Selenium::WebDriver::Chrome::Options.new(args: %w[no-sandbox headless disable-gpu])
+    Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+  end
+  Capybara.javascript_driver = :chrome
+else
+  ActionDispatch::SystemTestCase.driven_by(:selenium, using: :headless_chrome)
+end
 
 ActiveRecord::Migration.verbose = false
 CreateAllTables.up


### PR DESCRIPTION
This PR fixes test failures on Travis CI.

- Add required development dependency for all test cases.
- Update test configuration about Capybara webdriver for test cases running with Rails 5.2 and later.