### PR TITLE
Integrate enable getter and setter into attr_accessor

### DIFF
--- a/lib/html5_validators.rb
+++ b/lib/html5_validators.rb
@@ -5,12 +5,8 @@ require 'rails'
 module Html5Validators
   @enabled = true
 
-  def self.enabled
-    @enabled
-  end
-
-  def self.enabled=(enable)
-    @enabled = enable
+  class << self
+    attr_accessor :enabled
   end
 
   class Railtie < ::Rails::Railtie #:nodoc:

--- a/lib/html5_validators.rb
+++ b/lib/html5_validators.rb
@@ -10,7 +10,7 @@ module Html5Validators
   end
 
   class Railtie < ::Rails::Railtie #:nodoc:
-    initializer 'html5_validators' do |app|
+    initializer 'html5_validators' do
       ActiveSupport.on_load(:active_record) do
         require 'html5_validators/active_model/helper_methods'
         require 'html5_validators/active_model/validations'


### PR DESCRIPTION
In this PR, I'm refactoring `lib/html5_validators.rb`.

- integrates the enabled setter and getter into attr_accessor.
- omit unused argument in initializer block.