### PR TITLE
Supporting form_with in Rails 8.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,13 @@ jobs:
         rails_version: [edge, '8.0', '7.2', '7.1', '7.0', '6.1']
 
         include:
+          - ruby_version: '3.2'
+            activemodel_version: '8.0'
+
+          - ruby_version: '3.1'
+            activemodel_version: '7.2'
+          - ruby_version: '3.1'
+            activemodel_version: '7.1'
           - ruby_version: '3.1'
             activemodel_version: '7.0'
 

--- a/lib/html5_validators/action_view/form_helpers.rb
+++ b/lib/html5_validators/action_view/form_helpers.rb
@@ -12,7 +12,16 @@ module Html5Validators
         super
       end
 
-      if Rails::VERSION::STRING >= '5.1'
+      if Rails::VERSION::STRING >= '7.2'
+        def form_with(model: false, scope: nil, url: nil, format: nil, **options)
+          if model && model.respond_to?(:auto_html5_validation=)
+            if !Html5Validators.enabled || (options[:auto_html5_validation] == false)
+              model.auto_html5_validation = false
+            end
+          end
+          super
+        end
+      elsif Rails::VERSION::STRING >= '5.1'
         def form_with(model: nil, scope: nil, url: nil, format: nil, **options)
           if model && model.respond_to?(:auto_html5_validation=)
             if !Html5Validators.enabled || (options[:auto_html5_validation] == false)

--- a/test/fake_app.rb
+++ b/test/fake_app.rb
@@ -32,6 +32,10 @@ Rails.application.routes.draw do
       get :new_with_required_false
     end
   end
+
+  if Rails::VERSION::STRING >= '5.1'
+    resources :search, only: [:index]
+  end
 end
 
 # models
@@ -209,6 +213,15 @@ class ItemsController < ApplicationController
 <%= form_with model: @item, id: 'form_with' do |f| %>
 <%= f.text_field :name, required: false, id: 'item_name' %>
 <% end %>
+<% end %>
+    ERB
+  end
+end
+class SearchController < ApplicationController
+  def index
+    render inline: <<-ERB
+<%= form_with url: '/search', id: 'form_with' do |f| %>
+<%= f.search_field :query, id: 'query' %>
 <% end %>
     ERB
   end

--- a/test/features/without_model_test.rb
+++ b/test/features/without_model_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class WithoutModelTest < ActionDispatch::IntegrationTest
+  if Rails::VERSION::STRING >= '5.1'
+    sub_test_case 'without model' do
+      test 'form_with' do
+        visit '/search'
+        assert page.has_css? '#form_with input#query'
+      end
+    end
+  end
+end


### PR DESCRIPTION
@amatsuda 

I have created a PR to fix this issue💪
Please review it when you have a moment.

Close #32 

> Thank you for the wonderful gem✨
> 
> When I tried to upgrade a Rails application that using this gem to Rails 8.0, the following error occurred.
> 
> ```
> ActionView::Template::Error (Passed nil to the :model argument, expect an object or false)
> Caused by: ArgumentError (Passed nil to the :model argument, expect an object or false)
> 
> Information for: ActionView::Template::Error (Passed nil to the :model argument, expect an object or false):
>     1: <%= form_with url: '/search', id: 'form_with' do |f| %>
>     2: <%= f.search_field :query, id: 'query' %>
>     3: <% end %>
> ```
> 
> The cause is that the default value of the `model:` argument of `form_with` was changed from `nil` to `false` in Rails 7.2, and passing `nil` to the `model:` argument causes an error in Rails 8.0.
> 
> - https://github.com/rails/rails/pull/49943
> - https://github.com/rails/rails/pull/50931
> - https://github.com/rails/rails/pull/53374
>   - https://github.com/rails/rails/commit/0c150bacaaca7772121300ca124e3ed5392f6ab9
> 